### PR TITLE
[Feature/update-rules] Supports updating rules

### DIFF
--- a/cli/validation/src/index.ts
+++ b/cli/validation/src/index.ts
@@ -1,7 +1,7 @@
-import { getFirstHcsMessageInTopic, getTokenBalanceList, getHcsMessageByConsensusTimestamp, getHcsTokenInfo, getValidHcsMessagesInRange } from "./mirror";
+import * as crypto from "node:crypto";
+import { getFirstHcsMessageInTopic, getHcsMessageByConsensusTimestamp, getHcsTokenInfo, getTokenBalanceList, getValidHcsMessagesInRange } from "./mirror";
 import { Attestation, BallotInfo, HcsCreateProposalMessage, HcsMessage, HcsVoteMessage, RulesDefinition, Vote } from "./types";
 import { computeDiffInDays, getCurrentTime, isAddress, isAddressArrayOrUndefined, isFractionOrUndefined, isNonNegativeOrUndefined, isTimestamp } from "./util";
-import * as crypto from "node:crypto";
 
 export async function attest(hostname: string, ballotId: string): Promise<Attestation> {
     let ballotInfo: BallotInfo;
@@ -63,7 +63,6 @@ export async function attest(hostname: string, ballotId: string): Promise<Attest
                 }
             }
             if (!isTimestamp(createMessage.startTimestamp)) {
-                console.log(createMessage.startTimestamp);
                 throw new Error(`Proposal has an Invalid Voting Start Time.`);
             }
             if (!isTimestamp(createMessage.endTimestamp)) {

--- a/server/sample.env
+++ b/server/sample.env
@@ -32,6 +32,9 @@ HTS_TOKEN=0.0.30963729
 # Please note that votes cast after this start date for proposals
 # defined before this start date will not be considered valid and
 # logged as invalid in the server logs.
+# Please also note that proposals created after this start date
+# will not be considered unless there is a preceding rule message
+# submitted after this start date but before the proposal.
 HCS_START_DATE=1656606000.000000
 
 # Optional default value for the minimum fraction of eligible balance

--- a/server/src/app.controller.ts
+++ b/server/src/app.controller.ts
@@ -25,8 +25,10 @@ export class AppController {
 	 */
 	@Get('info')
 	getInfo(): any {
+		const currentRule = this.dataService.getLatestRule();
 		return {
 			...this.config,
+			...currentRule,
 			lastUpdated: this.dataService.getLastUpdated(),
 			version: process.env.npm_package_version || 'unknown',
 		};

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -2,13 +2,14 @@ import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { ScheduleModule } from '@nestjs/schedule';
 import { AppController } from './app.controller';
-import { DataService } from './services/data.service';
-import { HcsMessageListenerService } from './services/hcs-message-listener.service';
-import { MirrorClientService } from './services/mirror-client.service';
-import { HcsBallotProcessingService } from './services/hcs-ballot-processing.service';
-import { HcsVoteProcessingService } from './services/hcs-vote-processing.service';
-import { HcsMessageProcessingService } from './services/hcs-message-processing.service';
 import { AppConfiguration, loadAppConfiguration } from './models/app-configuration';
+import { DataService } from './services/data.service';
+import { HcsBallotProcessingService } from './services/hcs-ballot-processing.service';
+import { HcsMessageListenerService } from './services/hcs-message-listener.service';
+import { HcsMessageProcessingService } from './services/hcs-message-processing.service';
+import { HcsRulesProcessingService } from './services/hcs-rules-processing.service';
+import { HcsVoteProcessingService } from './services/hcs-vote-processing.service';
+import { MirrorClientService } from './services/mirror-client.service';
 /**
  * Main NestJS application module.
  */
@@ -25,6 +26,7 @@ import { AppConfiguration, loadAppConfiguration } from './models/app-configurati
 		HcsMessageProcessingService,
 		HcsBallotProcessingService,
 		HcsVoteProcessingService,
+		HcsRulesProcessingService,
 		MirrorClientService,
 		DataService,
 	],

--- a/server/src/models/app-configuration.ts
+++ b/server/src/models/app-configuration.ts
@@ -1,22 +1,11 @@
-import { date_to_keyString, EntityIdKeyString, is_entity_id, is_timestamp, TimestampKeyString } from '@bugbytes/hapi-util';
-import { MirrorError, MirrorRestClient } from '@bugbytes/hapi-mirror';
-import { ConfigService } from '@nestjs/config';
-import { TokenSummary } from './token-summary';
+import { EntityIdKeyString, TimestampKeyString, date_to_keyString, is_entity_id, is_timestamp } from '@bugbytes/hapi-util';
 import { Logger } from '@nestjs/common';
-import { RulesDefinition } from './rules-definition';
+import { ConfigService } from '@nestjs/config';
 /**
  * Service instance that parses and validates configuration information
  * used during startup and for other system functions.
  */
 export class AppConfiguration {
-	/**
-	 * A short title describing this HCS voting stream.
-	 */
-	public readonly title: string;
-	/**
-	 * A short description of the purpose of this HCS voting stream.
-	 */
-	public readonly description: string;
 	/**
 	 * The Mirror Node’s gRPC endpoint.
 	 */
@@ -30,64 +19,9 @@ export class AppConfiguration {
 	 */
 	public readonly hcsTopic: EntityIdKeyString;
 	/**
-	 * The Voting Token Information.
-	 */
-	public readonly hcsToken: TokenSummary;
-	/**
 	 * The consensus time at which to start processing HCS messages.
 	 */
 	public readonly hcsStartDate: TimestampKeyString;
-	/**
-	 * The minimum fraction of eligible balance that must vote for or
-	 * against a proposal.  (the sum of the balance of ineligible
-	 * accounts does not count in the quorum computation).
-	 *
-	 * Each proposal definition may, in turn, specify a higher threshold
-	 * value than what is specified here, but may not specify a value
-	 * lower than what is defined here.  If a proposal does not specify
-	 * a threshold value in its definition, the value defined here will
-	 * apply.
-	 */
-	public readonly minVotingThreshold: number;
-	/**
-	 * An array of crypto and/or contract accounts that are not allowed to
-	 * participate in voting.  The proposals threshold will not consider
-	 * their balances when computing quorom requirements.  The HCS
-	 * protocol allows each proposal to define a a list of inelegible
-	 * accounts in addition to what is defined here for each proposed ballot.
-	 * The resulting list of inelegible accounts will be the union of
-	 * the two lists.
-	 */
-	public readonly ineligibleAccounts: EntityIdKeyString[];
-	/**
-	 * The list of contracts or accounts that are allowed to
-	 * post ballot proposals into this stream.  If specified, only
-	 * ballot proposal definitions posted by accounts in this list
-	 * will be considered valid.  Validators must reject ballot
-	 * proposals not created by one of these listed accounts (in
-	 * other words, one of these accounts must be the payer of
-	 * the transaction submitting the HCS create ballot message)
-	 *
-	 * An empty list indicates that any account or contract may
-	 * create a ballot for this voting stream.
-	 */
-	public readonly ballotCreators: EntityIdKeyString[];
-	/**
-	 * The minimum voting window allowed (in days) for a ballot
-	 * proposal to be considered valid.  If not specified the
-	 * creator of the ballot may specify any voting window as
-	 * small or large as desired.
-	 */
-	public readonly minimumVotingPeriod: number;
-	/**
-	 * The minimum standoff for the beginning a voting window
-	 * (in days) from the creation of a ballot.  If not specified
-	 * a ballot window can open immediately upon creation of
-	 * a proposal ballot, otherwise to be considered valid,
-	 * the ballot's voting start period must be at least the
-	 * specified abount of days after the creation of the ballot.
-	 */
-	public readonly minimumStandoffPeriod: number;
 }
 /**
  * Loads the configuration properties for this HCS voting stream.
@@ -115,130 +49,29 @@ export async function loadAppConfiguration(configService: ConfigService): Promis
 		if (!is_entity_id(hcsTopic)) {
 			throw new Error('Invalid HCS Topic in configuration.');
 		}
-		const client = new MirrorRestClient(mirrorRest);
-		const rules = await getRules();
-		const hcsToken = await getHcsTokenInfo();
-
-		const title = rules.title || hcsToken.symbol;
-		const description = rules.description || hcsToken.name;
 		const hcsStartDate = computeStartDateFilter();
-		const ineligibleAccounts = verifyAccountList(rules.ineligibleAccounts);
-		const ballotCreators = verifyAccountList(rules.ballotCreators);
-		const minVotingThreshold = verifyMinVotingThreshold();
-		const minimumVotingPeriod = verifyMinimumVotingPeriod();
-		const minimumStandoffPeriod = verifyMinimumStandoffPeriod();
 
 		// For good measure, echo the computed
 		// configuration into the startup log
 		// to help troubleshooting when thing
 		// don't work as expected.
 		logger.log(`Configuration Loaded`);
-		logger.log(`Title: ${title}`);
-		logger.log(`Description: ${description}`);
 		logger.log(`HCS Topic: ${hcsTopic}`);
-		logger.log(`Voting Token: ${hcsToken.id}`);
 		if (hcsStartDate !== '0.0') {
 			logger.log(`Starting Timestamp: ${hcsStartDate}`);
 		} else {
-			logger.log('Starting Timestamp: none, replay entier stream');
+			logger.log('Starting Timestamp: none, replay entire stream');
 		}
-		logger.log(`Ballot Creators: ${ballotCreators.length > 0 ? ballotCreators : 'any account may submit a proposal'}`);
-		logger.log(`Ineligible Accounts: ${ineligibleAccounts.length > 0 ? ineligibleAccounts : 'none, all accounts may vote'}`);
-		logger.log(`Minimum Voting Threshold: ${minVotingThreshold > 0 ? minVotingThreshold.toString() : 'no quoroum required'}`);
-		logger.log(`Minimum Voting Period (days): ${minimumVotingPeriod > 0 ? minimumVotingPeriod.toString() : 'any length'}`);
-		logger.log(`Minimum Standoff Period (days): ${minimumStandoffPeriod > 0 ? minimumStandoffPeriod.toString() : 'no limit'}`);
 		logger.log(`GRPC Mirror Endpoint: ${mirrorGrpc}`);
 		logger.log(`REST Mirror Endpoint: ${mirrorRest}`);
 
 		return {
-			title,
-			description,
 			mirrorGrpc,
 			mirrorRest,
 			hcsTopic,
-			hcsToken,
 			hcsStartDate,
-			minVotingThreshold,
-			ineligibleAccounts,
-			ballotCreators,
-			minimumVotingPeriod,
-			minimumStandoffPeriod,
 		};
-		/**
-		 * Helper function to retrieve the defined rules for this HCS voting stream.
-		 * To be valid, the rules definition must be placed as the first message in
-		 * the stream and must conform to the `RulesDefinition` schema.
-		 */
-		async function getRules(): Promise<RulesDefinition> {
-			logger.log(`Retrieving rules configuration for hcs stream ${hcsTopic}.`);
-			const firstMessage = await getFirstMessage();
-			if (!firstMessage.message) {
-				throw new Error('First message in topic does not appear to define the voting rules, it is empty.');
-			}
-			const rules = extractPayload();
-			if (rules.type !== 'define-rules') {
-				throw new Error('First message in topic does not appear to define the voting rules.');
-			}
-			return rules;
-			/**
-			 * Attempts to retrieve the first message in an HCS
-			 * message stream, if it exists.
-			 */
-			async function getFirstMessage() {
-				try {
-					return await client.getMessage(hcsTopic as EntityIdKeyString, 1);
-				} catch (ex) {
-					if (ex instanceof MirrorError && ex.status === 400) {
-						throw new Error(`Topic ${hcsTopic} does not contain a configuration message.`);
-					}
-					throw ex;
-				}
-			}
-			/**
-			 * Attempts to extract the Rules Definition from the base64
-			 * encoded HCS message payload.
-			 */
-			function extractPayload(): RulesDefinition {
-				try {
-					const jsonMessage = Buffer.from(firstMessage.message, 'base64');
-					return JSON.parse(jsonMessage.toString('utf8')) as RulesDefinition;
-				} catch (ex) {
-					if (ex instanceof SyntaxError) {
-						throw new Error('First message in topic does not appear to define the voting rules, it is not parsable.');
-					}
-					throw ex;
-				}
-			}
-		}
-		/**
-		 * Helper function that queries the designated REST Mirror node for
-		 * information describing the HCS token representing voting weights.
-		 */
-		async function getHcsTokenInfo(): Promise<TokenSummary> {
-			logger.log(`Retrieving information for voting token ${rules.tokenId}.`);
-			if (!rules.tokenId) {
-				throw new Error('Voting Token ID is missing from configuration.');
-			}
-			if (!is_entity_id(rules.tokenId)) {
-				throw new Error(`The value ${rules.tokenId} is not a valid token ID.`);
-			}
-			try {
-				const record = await client.getTokenInfo(rules.tokenId);
-				return {
-					id: record.token_id as unknown as EntityIdKeyString,
-					symbol: record.symbol,
-					name: record.name,
-					decimals: parseInt(record.decimals, 10),
-					circulation: parseInt(record.total_supply, 10),
-					modified: record.modified_timestamp as unknown as TimestampKeyString,
-				};
-			} catch (ex) {
-				if (ex instanceof MirrorError && ex.status === 404) {
-					throw new Error(`Voting Token with id ${hcsTopic} does not appear to exist.`);
-				}
-				throw ex;
-			}
-		}
+
 		/**
 		 * Helper function that computes the starting date/time filter for the processing
 		 * the HCS voting stream, it is the later of either the time of message one
@@ -258,72 +91,6 @@ export async function loadAppConfiguration(configService: ConfigService): Promis
 				return override;
 			}
 			return '0.0';
-		}
-		/**
-		 * Helper function that examines a list of addresses to ensure
-		 * they conform to the 0.0.123 hedera addressing format.
-		 */
-		function verifyAccountList(accounts: string[] | null | undefined): EntityIdKeyString[] {
-			if (!accounts) {
-				return [];
-			}
-			if (Array.isArray(accounts)) {
-				for (const account of accounts) {
-					if (!is_entity_id(account)) {
-						throw new Error(`${account} is not a valid account id.`);
-					}
-				}
-				return accounts as EntityIdKeyString[];
-			}
-			throw new Error(`${JSON.stringify(accounts)} is not a valid list of account ids.`);
-		}
-		/**
-		 * Helper function that validates the minimum voting threshold
-		 * value (if specified), returns zero if not specified.
-		 */
-		function verifyMinVotingThreshold(): number {
-			if (!rules.minVotingThreshold) {
-				return 0;
-			}
-			if (Number.isNaN(rules.minVotingThreshold)) {
-				throw new Error(`${rules.minVotingThreshold} is not a valid voting threshold value.`);
-			}
-			if (rules.minVotingThreshold < 0 || rules.minVotingThreshold > 1) {
-				throw new Error('Voting threshold must be within the range of zero to one inclusive.');
-			}
-			return rules.minVotingThreshold;
-		}
-		/**
-		 * Helper function that validates the minimum voting period
-		 * (if specified), returns zero if not specified.
-		 */
-		function verifyMinimumVotingPeriod(): number {
-			if (!rules.minimumVotingPeriod) {
-				return 0;
-			}
-			if (Number.isNaN(rules.minimumVotingPeriod)) {
-				throw new Error(`${rules.minimumVotingPeriod} is not a valid minimum voting period.`);
-			}
-			if (rules.minimumVotingPeriod < 0) {
-				throw new Error('If specified, the minimum voting period must be non negative.');
-			}
-			return rules.minimumVotingPeriod;
-		}
-		/**
-		 * Helper function that validates the minimum stand-off period
-		 * (if specified), returns zero if not specified.
-		 */
-		function verifyMinimumStandoffPeriod(): number {
-			if (!rules.minimumStandoffPeriod) {
-				return 0;
-			}
-			if (Number.isNaN(rules.minimumStandoffPeriod)) {
-				throw new Error(`${rules.minimumStandoffPeriod} is not a valid voting starting standoff period.`);
-			}
-			if (rules.minimumStandoffPeriod < 0) {
-				throw new Error('If specified, the voting starting standoff period must be non negative.');
-			}
-			return rules.minimumStandoffPeriod;
 		}
 	} catch (configError) {
 		logger.error('Loading Configuration Failed.', configError);

--- a/server/src/models/app-configuration.ts
+++ b/server/src/models/app-configuration.ts
@@ -76,8 +76,10 @@ export async function loadAppConfiguration(configService: ConfigService): Promis
 		 * Helper function that computes the starting date/time filter for the processing
 		 * the HCS voting stream, it is the later of either the time of message one
 		 * (the configuration) or (if specified) the time designated in the environment
-		 * variable (HCS_START_DATE).  The system will ignore all ballots created before
-		 * the computed starting filter time.
+		 * variable (HCS_START_DATE).  The system will ignore all rules and ballots created
+		 * before the computed starting filter time. The system will also ignore all ballots
+		 * created after the computed starting filter time until such timestamp where a rule is
+		 * processed on the topic.
 		 */
 		function computeStartDateFilter(): TimestampKeyString {
 			const override = configService.get<string>('HCS_START_DATE');

--- a/server/src/models/ballot.ts
+++ b/server/src/models/ballot.ts
@@ -1,5 +1,5 @@
 import { EntityIdKeyString, TimestampKeyString } from '@bugbytes/hapi-util';
-import { Rule } from './rules';
+import { TokenSummary } from './token-summary';
 /**
  * Stores the details of a proposal ballot (excluding individual votes cast).
  */
@@ -81,12 +81,9 @@ export interface Ballot {
 	 * counting command line applications.
 	 */
 	checksum: string;
+
 	/**
-	 * The latest Rule that was defined prior to the creation of this
-	 * ballot.  This is used to determine the voting rules for this
-	 * ballot.
-	 *
-	 * @see Rule
+	 * Represents details of the voting token attached to this ballot instance.
 	 */
-	rule: Rule | undefined;
+	hcsToken: TokenSummary;
 }

--- a/server/src/models/ballot.ts
+++ b/server/src/models/ballot.ts
@@ -1,4 +1,5 @@
 import { EntityIdKeyString, TimestampKeyString } from '@bugbytes/hapi-util';
+import { Rule } from './rules';
 /**
  * Stores the details of a proposal ballot (excluding individual votes cast).
  */
@@ -80,4 +81,12 @@ export interface Ballot {
 	 * counting command line applications.
 	 */
 	checksum: string;
+	/**
+	 * The latest Rule that was defined prior to the creation of this
+	 * ballot.  This is used to determine the voting rules for this
+	 * ballot.
+	 *
+	 * @see Rule
+	 */
+	rule: Rule;
 }

--- a/server/src/models/ballot.ts
+++ b/server/src/models/ballot.ts
@@ -88,5 +88,5 @@ export interface Ballot {
 	 *
 	 * @see Rule
 	 */
-	rule: Rule;
+	rule: Rule | undefined;
 }

--- a/server/src/models/rules.ts
+++ b/server/src/models/rules.ts
@@ -1,0 +1,26 @@
+import { EntityIdKeyString, TimestampKeyString } from '@bugbytes/hapi-util';
+import { RulesDefinition } from './rules-definition';
+/**
+ * Stores the details of a single rule on the HCS topic.
+ */
+export interface Rule extends RulesDefinition {
+	/**
+	 * The date and time this rule was submitted,
+	 * in hedera 0000.0000 epoch string format.
+	 */
+	consensusTimestamp: TimestampKeyString;
+	/**
+	 * The hedera account that submitted the rule,
+	 * in 0.0.123 string format.
+	 */
+	payerId: EntityIdKeyString;
+}
+/**
+ * Array of rules for the HCS topic.
+ */
+export interface Rules {
+	/**
+	 * Array of rules for the HCS topic.
+	 */
+	votes: Rule[];
+}

--- a/server/src/models/rules.ts
+++ b/server/src/models/rules.ts
@@ -1,9 +1,14 @@
 import { EntityIdKeyString, TimestampKeyString } from '@bugbytes/hapi-util';
 import { RulesDefinition } from './rules-definition';
+import { TokenSummary } from './token-summary';
 /**
  * Stores the details of a single rule on the HCS topic.
  */
 export interface Rule extends RulesDefinition {
+	/**
+	 * Represents details of the voting token attached to this server instance.
+	 */
+	hcsToken?: TokenSummary;
 	/**
 	 * The date and time this rule was submitted,
 	 * in hedera 0000.0000 epoch string format.

--- a/server/src/services/data.service.ts
+++ b/server/src/services/data.service.ts
@@ -263,7 +263,7 @@ async function computeChecksumIfNecessary(client: MirrorClientService, ballot: B
 	// balance necessary to pass the ballot.
 	let threshold = 0;
 	if (ballot.minVotingThreshold > 0) {
-		const circulation = (await client.getTokenInfo(ballot.rule.tokenId, ballot.startTimestamp)).circulation;
+		const circulation = (await client.getTokenInfo(ballot.hcsToken.id, ballot.startTimestamp)).circulation;
 		const ineligible =
 			ballot.ineligibleAccounts.length > 0
 				? (await Promise.all(ballot.ineligibleAccounts.map((a) => client.getTokenBalance(a, ballot.tokenId, ballot.startTimestamp))))

--- a/server/src/services/data.service.ts
+++ b/server/src/services/data.service.ts
@@ -192,17 +192,26 @@ export class DataService {
 	}
 
 	/**
-	 * Retrieves the latest rule before or on a given consensus timestamp.
+	 * Retrieves the rule corresponding to the given consensus timestamp.
 	 * @param consensusTimestamp The consensus timestamp of the rule to retrieve.
 	 * @returns The rule for the given consensus timestamp or undefined if no rule exists.
 	 * */
 	getRule(consensusTimestamp: TimestampKeyString): Rule | undefined {
+		return rules.get(consensusTimestamp);
+	}
+
+	/**
+	 * Retrieves the latest rule before or on a given consensus timestamp. If no timestamp is provided, the latest rule is returned.
+	 * @param consensusTimestamp Optional consensus timestamp of the rule to retrieve.
+	 * @returns The rule for the given consensus timestamp or undefined if no rule exists.
+	 * */
+	getLatestRule(consensusTimestamp?: TimestampKeyString): Rule | undefined {
 		if (rules.has(consensusTimestamp)) {
 			return rules.get(consensusTimestamp);
 		}
 
 		return Array.from(rules.values())
-			.filter((r) => r.consensusTimestamp < consensusTimestamp)
+			.filter((r) => (consensusTimestamp ? r.consensusTimestamp < consensusTimestamp : true))
 			.sort((a, b) => b.consensusTimestamp.localeCompare(a.consensusTimestamp))[0];
 	}
 
@@ -216,18 +225,6 @@ export class DataService {
 		}
 
 		return Array.from(rules.values()).sort((a, b) => a.consensusTimestamp.localeCompare(b.consensusTimestamp))[0];
-	}
-
-	/**
-	 * Retrieves the rule that was submitted last. This is used as the primary rule used for all ballots.
-	 * @returns The Rule that was submitted last or undefined if no rules exist yet.
-	 * */
-	getLatestRule(): Rule | undefined {
-		if (rules.size === 0) {
-			return undefined;
-		}
-
-		return Array.from(rules.values()).sort((a, b) => b.consensusTimestamp.localeCompare(a.consensusTimestamp))[0];
 	}
 }
 /**

--- a/server/src/services/data.service.ts
+++ b/server/src/services/data.service.ts
@@ -197,8 +197,12 @@ export class DataService {
 	 * @returns The rule for the given consensus timestamp or undefined if no rule exists.
 	 * */
 	getRule(consensusTimestamp: TimestampKeyString): Rule | undefined {
+		if (rules.has(consensusTimestamp)) {
+			return rules.get(consensusTimestamp);
+		}
+
 		return Array.from(rules.values())
-			.filter((r) => r.consensusTimestamp <= consensusTimestamp)
+			.filter((r) => r.consensusTimestamp < consensusTimestamp)
 			.sort((a, b) => b.consensusTimestamp.localeCompare(a.consensusTimestamp))[0];
 	}
 

--- a/server/src/services/data.service.ts
+++ b/server/src/services/data.service.ts
@@ -192,12 +192,14 @@ export class DataService {
 	}
 
 	/**
-	 * Retrieves the rule for a given consensus timestamp.
+	 * Retrieves the latest rule before or on a given consensus timestamp.
 	 * @param consensusTimestamp The consensus timestamp of the rule to retrieve.
 	 * @returns The rule for the given consensus timestamp or undefined if no rule exists.
 	 * */
 	getRule(consensusTimestamp: TimestampKeyString): Rule | undefined {
-		return rules.get(consensusTimestamp);
+		return Array.from(rules.values())
+			.filter((r) => r.consensusTimestamp <= consensusTimestamp)
+			.sort((a, b) => b.consensusTimestamp.localeCompare(a.consensusTimestamp))[0];
 	}
 
 	/**
@@ -260,7 +262,7 @@ async function computeChecksumIfNecessary(client: MirrorClientService, ballot: B
 	// balance necessary to pass the ballot.
 	let threshold = 0;
 	if (ballot.minVotingThreshold > 0) {
-		const circulation = (await client.getHcsTokenSummary(ballot.startTimestamp)).circulation;
+		const circulation = (await client.getTokenInfo(ballot.rule.tokenId, ballot.startTimestamp)).circulation;
 		const ineligible =
 			ballot.ineligibleAccounts.length > 0
 				? (await Promise.all(ballot.ineligibleAccounts.map((a) => client.getTokenBalance(a, ballot.tokenId, ballot.startTimestamp))))

--- a/server/src/services/hcs-ballot-processing.service.ts
+++ b/server/src/services/hcs-ballot-processing.service.ts
@@ -53,15 +53,7 @@ export class HcsBallotProcessingService {
 	 * list of proposed ballots).
 	 */
 	processMessage(hcsMessage: ConsensusTopicResponse, hcsMirrorRecord: MessageInfo, hcsPayload: any): () => Promise<void> {
-		// Get the rules for this ballot.
 		const rule = this.dataService.getRule(hcsMirrorRecord.consensus_timestamp as unknown as TimestampKeyString);
-
-		if (!rule) {
-			this.logger.verbose(
-				`Message ${hcsMessage.sequenceNumber} failed create-ballot validation: No rule found for ballot. Make sure a define-rules message is submitted before creating a ballot.`,
-			);
-			return;
-		}
 
 		const ballot: Ballot = {
 			consensusTimestamp: hcsMirrorRecord.consensus_timestamp as unknown as TimestampKeyString,
@@ -81,7 +73,12 @@ export class HcsBallotProcessingService {
 			checksum: undefined,
 			rule,
 		};
-		if (!is_timestamp(ballot.consensusTimestamp)) {
+
+		if (!rule) {
+			this.logger.verbose(
+				`Message ${hcsMessage.sequenceNumber} failed create-ballot validation: No rule found for ballot. Make sure a define-rules message is submitted before creating a ballot.`,
+			);
+		} else if (!is_timestamp(ballot.consensusTimestamp)) {
 			this.logger.verbose(`Message ${hcsMessage.sequenceNumber} failed create-ballot validation: Invalid Consensus Timestamp.`);
 		} else if (!is_entity_id(ballot.tokenId)) {
 			this.logger.verbose(`Message ${hcsMessage.sequenceNumber} failed create-ballot validation: Invalid Token ID.`);

--- a/server/src/services/hcs-ballot-processing.service.ts
+++ b/server/src/services/hcs-ballot-processing.service.ts
@@ -53,8 +53,6 @@ export class HcsBallotProcessingService {
 	 * list of proposed ballots).
 	 */
 	processMessage(hcsMessage: ConsensusTopicResponse, hcsMirrorRecord: MessageInfo, hcsPayload: any): () => Promise<void> {
-		const rule = this.dataService.getRule(hcsMirrorRecord.consensus_timestamp as unknown as TimestampKeyString);
-
 		const ballot: Ballot = {
 			consensusTimestamp: hcsMirrorRecord.consensus_timestamp as unknown as TimestampKeyString,
 			tokenId: hcsPayload.tokenId,
@@ -66,28 +64,20 @@ export class HcsBallotProcessingService {
 			choices: hcsPayload.choices,
 			startTimestamp: hcsPayload.startTimestamp,
 			endTimestamp: hcsPayload.endTimestamp,
-			minVotingThreshold: hcsPayload.threshold || rule.minVotingThreshold || 0,
+			minVotingThreshold: hcsPayload.threshold || 0,
 			ineligibleAccounts: hcsPayload.ineligible || [],
 			tally: new Array(hcsPayload.choices.length).fill(0),
 			winner: undefined,
 			checksum: undefined,
-			rule,
+			rule: undefined,
 		};
 
-		if (!rule) {
-			this.logger.verbose(
-				`Message ${hcsMessage.sequenceNumber} failed create-ballot validation: No rule found for ballot. Make sure a define-rules message is submitted before creating a ballot.`,
-			);
-		} else if (!is_timestamp(ballot.consensusTimestamp)) {
+		if (!is_timestamp(ballot.consensusTimestamp)) {
 			this.logger.verbose(`Message ${hcsMessage.sequenceNumber} failed create-ballot validation: Invalid Consensus Timestamp.`);
 		} else if (!is_entity_id(ballot.tokenId)) {
 			this.logger.verbose(`Message ${hcsMessage.sequenceNumber} failed create-ballot validation: Invalid Token ID.`);
-		} else if (ballot.tokenId !== ballot.rule.tokenId) {
-			this.logger.verbose(`Message ${hcsMessage.sequenceNumber} failed create-ballot validation: contains a create-ballot for a different payment token ID.`);
 		} else if (!is_entity_id(ballot.payerId)) {
 			this.logger.verbose(`Message ${hcsMessage.sequenceNumber} failed create-ballot validation: Invalid Payer ID.`);
-		} else if (rule.ballotCreators.length > 0 && rule.ballotCreators.indexOf(ballot.payerId) === -1) {
-			this.logger.verbose(`Message ${hcsMessage.sequenceNumber} failed create-ballot validation: Payer ID is not on the allowed list.`);
 		} else if (!ballot.title) {
 			this.logger.verbose(`Message ${hcsMessage.sequenceNumber} failed create-ballot validation: Empty title.`);
 		} else if (!ballot.description) {
@@ -104,25 +94,13 @@ export class HcsBallotProcessingService {
 			this.logger.verbose(`Message ${hcsMessage.sequenceNumber} failed create-ballot validation: Invalid Voting Completion Time.`);
 		} else if (ballot.startTimestamp >= ballot.endTimestamp) {
 			this.logger.verbose(`Message ${hcsMessage.sequenceNumber} failed create-ballot validation: Voting ending time preceeds starting.`);
-		} else if (computeDiffInDays(ballot.startTimestamp, ballot.endTimestamp) < rule.minVotingThreshold) {
-			this.logger.verbose(
-				`Message ${hcsMessage.sequenceNumber} failed create-ballot validation: Voting ending time does not permit required voting windo of ${rule.minVotingThreshold} days.`,
-			);
 		} else if (ballot.consensusTimestamp > ballot.startTimestamp) {
 			this.logger.verbose(
 				`Message ${hcsMessage.sequenceNumber} failed create-ballot validation: Proposal Voting Starting Time preceeds Proposal Creation Time.`,
 			);
-		} else if (computeDiffInDays(ballot.consensusTimestamp, ballot.startTimestamp) < rule.minimumStandoffPeriod) {
-			this.logger.verbose(
-				`Message ${hcsMessage.sequenceNumber} failed create-ballot validation: Voting starting time is less than ${rule.minimumStandoffPeriod} days from ballot creation.`,
-			);
 		} else if (isNaN(ballot.minVotingThreshold) || ballot.minVotingThreshold < 0 || ballot.minVotingThreshold > 1) {
 			this.logger.verbose(
 				`Message ${hcsMessage.sequenceNumber} failed create-ballot validation: Invalid Minimum Voting Threshold, must be a fraction between 0 and 1.0 inclusive.`,
-			);
-		} else if (ballot.minVotingThreshold < rule.minVotingThreshold) {
-			this.logger.verbose(
-				`Message ${hcsMessage.sequenceNumber} failed create-ballot validation: Invalid Minimum Voting Threshold, must be equal to or greater than global configuration of ${rule.minVotingThreshold}.`,
 			);
 		} else if (!Array.isArray(ballot.ineligibleAccounts)) {
 			this.logger.verbose(`Message ${hcsMessage.sequenceNumber} failed create-ballot validation: Ineligible account list is not an array.`);
@@ -131,11 +109,38 @@ export class HcsBallotProcessingService {
 		} else if (-1 !== ballot.ineligibleAccounts.findIndex((a) => !is_entity_id(a))) {
 			this.logger.verbose(`Message ${hcsMessage.sequenceNumber} failed create-ballot validation: Found invalid account id in list of inelegible accounts.`);
 		} else {
-			ballot.ineligibleAccounts = [...new Set([...ballot.ineligibleAccounts, ...rule.ineligibleAccounts])];
 			return async () => {
-				if (await this.dataService.getBallot(ballot.consensusTimestamp)) {
+				const rule = this.dataService.getLatestRule(hcsMirrorRecord.consensus_timestamp as unknown as TimestampKeyString);
+
+				if (!rule) {
+					this.logger.verbose(
+						`Message ${hcsMessage.sequenceNumber} failed create-ballot validation: No rule found for ballot. Make sure a define-rules message is submitted before creating a ballot.`,
+					);
+				} else if (rule.ballotCreators?.length > 0 && rule.ballotCreators.indexOf(ballot.payerId) === -1) {
+					this.logger.verbose(`Message ${hcsMessage.sequenceNumber} failed create-ballot validation: Payer ID is not on the allowed list.`);
+				} else if (await this.dataService.getBallot(ballot.consensusTimestamp)) {
 					this.logger.verbose(`Message ${hcsMessage.sequenceNumber} failed create-ballot validation: Ballot with same consensus timestamp already exists.`);
+				} else if (ballot.minVotingThreshold < rule.minVotingThreshold) {
+					this.logger.verbose(
+						`Message ${hcsMessage.sequenceNumber} failed create-ballot validation: Invalid Minimum Voting Threshold, must be equal to or greater than global configuration of ${rule.minVotingThreshold}.`,
+					);
+				} else if (computeDiffInDays(ballot.consensusTimestamp, ballot.startTimestamp) < rule.minimumStandoffPeriod) {
+					this.logger.verbose(
+						`Message ${hcsMessage.sequenceNumber} failed create-ballot validation: Voting starting time is less than ${rule.minimumStandoffPeriod} days from ballot creation.`,
+					);
+				} else if (computeDiffInDays(ballot.startTimestamp, ballot.endTimestamp) < rule.minVotingThreshold) {
+					this.logger.verbose(
+						`Message ${hcsMessage.sequenceNumber} failed create-ballot validation: Voting ending time does not permit required voting windo of ${rule.minVotingThreshold} days.`,
+					);
+				} else if (ballot.tokenId !== rule.tokenId) {
+					this.logger.verbose(
+						`Message ${hcsMessage.sequenceNumber} failed create-ballot validation: contains a create-ballot for a different payment token ID.`,
+					);
 				} else {
+					ballot.ineligibleAccounts = [...new Set([...ballot.ineligibleAccounts, ...(rule.ineligibleAccounts ? rule.ineligibleAccounts : [])])];
+					ballot.minVotingThreshold = ballot.minVotingThreshold || rule.minVotingThreshold || 0;
+					ballot.rule = rule;
+
 					this.dataService.setBallot(ballot);
 					this.logger.verbose(`Message ${hcsMessage.sequenceNumber} added Ballot ${ballot.consensusTimestamp} to list.`);
 				}

--- a/server/src/services/hcs-ballot-processing.service.ts
+++ b/server/src/services/hcs-ballot-processing.service.ts
@@ -69,7 +69,7 @@ export class HcsBallotProcessingService {
 			tally: new Array(hcsPayload.choices.length).fill(0),
 			winner: undefined,
 			checksum: undefined,
-			rule: undefined,
+			hcsToken: undefined,
 		};
 
 		if (!is_timestamp(ballot.consensusTimestamp)) {
@@ -139,7 +139,7 @@ export class HcsBallotProcessingService {
 				} else {
 					ballot.ineligibleAccounts = [...new Set([...ballot.ineligibleAccounts, ...(rule.ineligibleAccounts ? rule.ineligibleAccounts : [])])];
 					ballot.minVotingThreshold = ballot.minVotingThreshold || rule.minVotingThreshold || 0;
-					ballot.rule = rule;
+					ballot.hcsToken = rule.hcsToken;
 
 					this.dataService.setBallot(ballot);
 					this.logger.verbose(`Message ${hcsMessage.sequenceNumber} added Ballot ${ballot.consensusTimestamp} to list.`);

--- a/server/src/services/hcs-message-listener.service.ts
+++ b/server/src/services/hcs-message-listener.service.ts
@@ -182,7 +182,7 @@ export class HcsMessageListenerService {
 		const timestamp = keyString_to_timestamp(latestMessage.consensus_timestamp as TimestampKeyString);
 		const envTimestamp = keyString_to_timestamp(this.config.hcsStartDate);
 
-		if (this.sequenceNumber === 1 && !envTimestamp) {
+		if (this.sequenceNumber === 1 && (!envTimestamp || (envTimestamp.seconds === 0 && envTimestamp.nanos === 0))) {
 			return timestamp;
 		}
 

--- a/server/src/services/hcs-message-processing.service.ts
+++ b/server/src/services/hcs-message-processing.service.ts
@@ -197,7 +197,6 @@ export class HcsMessageProcessingService {
 		if (!hcsPayload) {
 			return this.discardMessage;
 		}
-		console.log(`Processing message ${hcsMessage.sequenceNumber} of type ${hcsPayload['type']}`);
 
 		const hcsMirrorRecord = await this.getMirrorRecord(hcsMessage.sequenceNumber);
 		if (!hcsMirrorRecord) {
@@ -228,7 +227,7 @@ export class HcsMessageProcessingService {
 	private parsePayload(hcsMessage: ConsensusTopicResponse): any | null {
 		let hcsPayloadAsString: string;
 		let hcsPayload: any;
-		console.log(hcsMessage);
+
 		if (hcsMessage.chunkInfo && hcsMessage.chunkInfo.total > 1) {
 			this.logger.verbose(`Message ${hcsMessage.sequenceNumber} has chunks, which are not supported.`);
 			return null;

--- a/server/src/services/hcs-message-processing.service.ts
+++ b/server/src/services/hcs-message-processing.service.ts
@@ -193,10 +193,13 @@ export class HcsMessageProcessingService {
 		if (!hcsPayload) {
 			return this.discardMessage;
 		}
+		console.log(`Processing message ${hcsMessage.sequenceNumber} of type ${hcsPayload['type']}`);
+
 		const hcsMirrorRecord = await this.getMirrorRecord(hcsMessage.sequenceNumber);
 		if (!hcsMirrorRecord) {
 			return this.discardMessage;
 		}
+
 		switch (hcsPayload['type']) {
 			case 'create-ballot':
 				return this.hcsBallotProcessor.processMessage(hcsMessage, hcsMirrorRecord, hcsPayload);

--- a/server/src/services/hcs-message-processing.service.ts
+++ b/server/src/services/hcs-message-processing.service.ts
@@ -99,15 +99,19 @@ export class HcsMessageProcessingService {
 			previousTask = null;
 			// Only perform a ping if this task is at the end of the queue
 			if (this.currentTask === thisHeartbeat) {
-				const lastProcessedTimestamp = this.dataService.getLastUpdated();
-				const lastHcsMessageTimestamp = await this.mirrorClient.getLatestMessageTimestamp();
-				// If the data store is "behind", we do not want to do anything
-				// at the moment, skip this heartbeat to let the hcs message queue
-				// to catch up before updating to the current ledger timestamp.
-				if (lastHcsMessageTimestamp <= lastProcessedTimestamp) {
-					const ledgerTimestamp = await this.mirrorClient.getLatestTransactionTimestamp();
-					this.dataService.setLastUpdated(ledgerTimestamp);
-					this.logger.verbose(`Heartbeat ${ledgerTimestamp}: waiting for HCS Messages`);
+				try {
+					const lastProcessedTimestamp = this.dataService.getLastUpdated();
+					const lastHcsMessageTimestamp = await this.mirrorClient.getLatestMessageTimestamp();
+					// If the data store is "behind", we do not want to do anything
+					// at the moment, skip this heartbeat to let the hcs message queue
+					// to catch up before updating to the current ledger timestamp.
+					if (lastHcsMessageTimestamp <= lastProcessedTimestamp) {
+						const ledgerTimestamp = await this.mirrorClient.getLatestTransactionTimestamp();
+						this.dataService.setLastUpdated(ledgerTimestamp);
+						this.logger.verbose(`Heartbeat ${ledgerTimestamp}: waiting for HCS Messages`);
+					}
+				} catch (err) {
+					this.logger.error(`Heartbeat failed: ${err.message || JSON.stringify(err)}`);
 				}
 			}
 		};

--- a/server/src/services/hcs-rules-processing.service.ts
+++ b/server/src/services/hcs-rules-processing.service.ts
@@ -1,9 +1,10 @@
-import { MessageInfo } from '@bugbytes/hapi-mirror';
+import { MessageInfo, MirrorError } from '@bugbytes/hapi-mirror';
 import { ConsensusTopicResponse } from '@bugbytes/hapi-proto';
-import { EntityIdKeyString, TimestampKeyString } from '@bugbytes/hapi-util';
+import { EntityIdKeyString, TimestampKeyString, is_entity_id } from '@bugbytes/hapi-util';
 import { Injectable, Logger } from '@nestjs/common';
 import { Rule } from 'src/models/rules';
 import { RulesDefinition } from 'src/models/rules-definition';
+import { TokenSummary } from 'src/models/token-summary';
 import { noop } from 'src/util/noop';
 import { DataService } from './data.service';
 import { MirrorClientService } from './mirror-client.service';
@@ -69,13 +70,117 @@ export class HcsRulesProcessingService {
 				if (this.dataService.getRule(rule.consensusTimestamp)) {
 					this.logger.verbose(`Message ${hcsMessage.sequenceNumber} failed rule validation: Rule already exists.`);
 				} else {
-					this.dataService.setRule(rule);
-					this.logger.log(`Message for ${hcsMessage.sequenceNumber} successfully added rule.`);
+					try {
+						const hcsToken = await this.getHcsTokenInfo(rule);
+
+						rule.title = rule.title || hcsToken.symbol;
+						rule.description = rule.description || hcsToken.name;
+						this.verifyAccountList(rule.ineligibleAccounts);
+						this.verifyAccountList(rule.ballotCreators);
+						this.verifyMinVotingThreshold(rule);
+						this.verifyMinimumVotingPeriod(rule);
+						this.verifyMinimumStandoffPeriod(rule);
+
+						this.dataService.setRule(rule);
+
+						this.logger.verbose(`Message for ${hcsMessage.sequenceNumber} successfully added rule.`);
+					} catch (ex) {
+						this.logger.error(`Message ${hcsMessage.sequenceNumber} failed rule validation: ${ex.message}`);
+					}
 				}
 			};
 		}
 
 		// Not a valid message, do nothing.
 		return noop;
+	}
+
+	/**
+	 * Helper function that queries the designated REST Mirror node for
+	 * information describing the HCS token representing voting weights.
+	 */
+	private async getHcsTokenInfo(rule: Rule): Promise<TokenSummary> {
+		this.logger.log(`Retrieving information for voting token ${rule.tokenId}.`);
+		if (!rule.tokenId) {
+			throw new Error('Voting Token ID is missing from configuration.');
+		}
+		if (!is_entity_id(rule.tokenId)) {
+			throw new Error(`The value ${rule.tokenId} is not a valid token ID.`);
+		}
+		try {
+			return this.mirrorClient.getTokenInfo(rule.tokenId);
+		} catch (ex) {
+			if (ex instanceof MirrorError && ex.status === 404) {
+				throw new Error(`Voting Token with id ${rule.tokenId} does not appear to exist.`);
+			}
+			throw ex;
+		}
+	}
+
+	/**
+	 * Helper function that examines a list of addresses to ensure
+	 * they conform to the 0.0.123 hedera addressing format.
+	 */
+	private verifyAccountList(accounts: string[] | null | undefined): EntityIdKeyString[] {
+		if (!accounts) {
+			return [];
+		}
+		if (Array.isArray(accounts)) {
+			for (const account of accounts) {
+				if (!is_entity_id(account)) {
+					throw new Error(`${account} is not a valid account id.`);
+				}
+			}
+			return accounts as EntityIdKeyString[];
+		}
+		throw new Error(`${JSON.stringify(accounts)} is not a valid list of account ids.`);
+	}
+	/**
+	 * Helper function that validates the minimum voting threshold
+	 * value (if specified), returns zero if not specified.
+	 */
+	private verifyMinVotingThreshold(rule: Rule): number {
+		if (!rule.minVotingThreshold) {
+			return 0;
+		}
+		if (Number.isNaN(rule.minVotingThreshold)) {
+			throw new Error(`${rule.minVotingThreshold} is not a valid voting threshold value.`);
+		}
+		if (rule.minVotingThreshold < 0 || rule.minVotingThreshold > 1) {
+			throw new Error('Voting threshold must be within the range of zero to one inclusive.');
+		}
+		return rule.minVotingThreshold;
+	}
+	/**
+	 * Helper function that validates the minimum voting period
+	 * (if specified), returns zero if not specified.
+	 */
+	private verifyMinimumVotingPeriod(rule: Rule): number {
+		if (!rule.minimumVotingPeriod) {
+			return 0;
+		}
+		if (Number.isNaN(rule.minimumVotingPeriod)) {
+			throw new Error(`${rule.minimumVotingPeriod} is not a valid minimum voting period.`);
+		}
+		if (rule.minimumVotingPeriod < 0) {
+			throw new Error('If specified, the minimum voting period must be non negative.');
+		}
+		return rule.minimumVotingPeriod;
+	}
+	/**
+	 * Helper function that validates the minimum stand-off period
+	 * (if specified), returns zero if not specified.
+	 */
+	private verifyMinimumStandoffPeriod(rule: Rule): number {
+		if (!rule.minimumStandoffPeriod) {
+			return 0;
+		}
+		if (Number.isNaN(rule.minimumStandoffPeriod)) {
+			throw new Error(`${rule.minimumStandoffPeriod} is not a valid voting starting standoff period.`);
+		}
+		if (rule.minimumStandoffPeriod < 0) {
+			throw new Error('If specified, the voting starting standoff period must be non negative.');
+		}
+		return rule.minimumStandoffPeriod;
 	}
 }

--- a/server/src/services/hcs-rules-processing.service.ts
+++ b/server/src/services/hcs-rules-processing.service.ts
@@ -1,0 +1,81 @@
+import { MessageInfo } from '@bugbytes/hapi-mirror';
+import { ConsensusTopicResponse } from '@bugbytes/hapi-proto';
+import { EntityIdKeyString, TimestampKeyString } from '@bugbytes/hapi-util';
+import { Injectable, Logger } from '@nestjs/common';
+import { Rule } from 'src/models/rules';
+import { RulesDefinition } from 'src/models/rules-definition';
+import { noop } from 'src/util/noop';
+import { DataService } from './data.service';
+import { MirrorClientService } from './mirror-client.service';
+/**
+ * Specialized service instance that validates the rules added to the HCS topic,
+ * and records valid rules with the data storage service.
+ */
+@Injectable()
+export class HcsRulesProcessingService {
+	/**
+	 * The service's logger instance.
+	 */
+	private readonly logger = new Logger(HcsRulesProcessingService.name);
+	/**
+	 * Public constructor, called by the NextJS runtime dependency injection services.
+	 *
+	 * @param mirrorClient Data service for retrieving additional information
+	 * from the mirror node via its REST interface.
+	 *
+	 * @param dataService The rules data storage (state) service.
+	 */
+	constructor(private readonly mirrorClient: MirrorClientService, private readonly dataService: DataService) {}
+	/**
+	 * Process a potential define-rules HCS native message.  If the message
+	 * passes validation it is forwarded to the data service for storage.
+	 *
+	 * @param hcsMessage The raw hcsMessage to be processed.
+	 *
+	 * @param hcsMirrorRecord The raw HCS mirror record associated with this
+	 * message, useful for retrieving the payer account associated with the message.
+	 *
+	 * @param hcsPayload The parsed message payload of the raw message, should
+	 * contain metadata defining the rules of the governance (to be validated by this method).
+	 *
+	 * A payload might typically look like this:
+	 * {
+	 *      "type": "define-rules",
+	 *      "title": "Governance Voting Platform",
+	 *      "description": "A decentralized voting platform for Hedera Hashgraph",
+	 *      "tokenId": "0.0.123456",
+	 *      "minVotingThreshold": 0.1,
+	 *      "minimumVotingPeriod": 7,
+	 *      "minimumStandoffPeriod": 0
+	 * }
+	 *
+	 * @returns A promise that when completed indicates processing of this message
+	 * is complete (regardless of whether it was found to be valid and added to the
+	 * list of rules).
+	 */
+	processMessage(hcsMessage: ConsensusTopicResponse, hcsMirrorRecord: MessageInfo, hcsPayload: RulesDefinition): () => Promise<void> {
+		const rule: Rule = {
+			...hcsPayload,
+			consensusTimestamp: hcsMirrorRecord.consensus_timestamp as unknown as TimestampKeyString,
+			payerId: hcsMirrorRecord.payer_account_id as unknown as EntityIdKeyString,
+		};
+
+		const firstRule = this.dataService.getFirstRule();
+
+		if (firstRule && firstRule.payerId !== rule.payerId) {
+			this.logger.verbose(`Message ${hcsMessage.sequenceNumber} failed rule validation: Rule wasn't submitted by the first rule submitter.`);
+		} else {
+			return async () => {
+				if (this.dataService.getRule(rule.consensusTimestamp)) {
+					this.logger.verbose(`Message ${hcsMessage.sequenceNumber} failed rule validation: Rule already exists.`);
+				} else {
+					this.dataService.setRule(rule);
+					this.logger.log(`Message for ${hcsMessage.sequenceNumber} successfully added rule.`);
+				}
+			};
+		}
+
+		// Not a valid message, do nothing.
+		return noop;
+	}
+}

--- a/server/src/services/mirror-client.service.ts
+++ b/server/src/services/mirror-client.service.ts
@@ -1,8 +1,9 @@
-import { Injectable, Logger } from '@nestjs/common';
 import { MessageInfo, MirrorError, MirrorRestClient, TokenBalanceInfo } from '@bugbytes/hapi-mirror';
 import { EntityIdKeyString, TimestampKeyString } from '@bugbytes/hapi-util';
-import { TokenSummary } from 'src/models/token-summary';
+import { Injectable, Logger } from '@nestjs/common';
 import { AppConfiguration } from 'src/models/app-configuration';
+import { TokenSummary } from 'src/models/token-summary';
+import { DataService } from './data.service';
 /**
  * Provides various methods for retrieving information from a remote
  * Hedera Mirror Node REST API.
@@ -23,18 +24,22 @@ export class MirrorClientService {
 	 * @param config The application's configuration containing details
 	 * such as the id of the voting token.
 	 */
-	constructor(private readonly config: AppConfiguration) {
+	constructor(private readonly config: AppConfiguration, private readonly dataService: DataService) {
 		this.client = new MirrorRestClient(this.config.mirrorRest);
 	}
+
 	/**
-	 * Retrieves the token information for the token identified in the
-	 * system-wide configuration.
+	 * Retrieves the token information for the token passed in.
+	 *
+	 * @param tokenId The associated token identifier.
+	 *
+	 * @param timestamp The timestamp at which the balance value is requested.
 	 *
 	 * @returns A `TokenSummary` object describing the voting token to be
 	 * used in processing.  If not found, an error is raised.
 	 */
-	async getHcsTokenSummary(timestamp: TimestampKeyString | undefined = undefined): Promise<TokenSummary> {
-		const record = await this.client.getTokenInfo(this.config.hcsToken.id, timestamp);
+	async getTokenInfo(tokenId: EntityIdKeyString, timestamp?: TimestampKeyString): Promise<TokenSummary> {
+		const record = await this.client.getTokenInfo(tokenId, timestamp);
 		return {
 			id: record.token_id as unknown as EntityIdKeyString,
 			symbol: record.symbol,

--- a/server/src/services/mirror-client.service.ts
+++ b/server/src/services/mirror-client.service.ts
@@ -3,7 +3,6 @@ import { EntityIdKeyString, TimestampKeyString } from '@bugbytes/hapi-util';
 import { Injectable, Logger } from '@nestjs/common';
 import { AppConfiguration } from 'src/models/app-configuration';
 import { TokenSummary } from 'src/models/token-summary';
-import { DataService } from './data.service';
 /**
  * Provides various methods for retrieving information from a remote
  * Hedera Mirror Node REST API.
@@ -24,7 +23,7 @@ export class MirrorClientService {
 	 * @param config The application's configuration containing details
 	 * such as the id of the voting token.
 	 */
-	constructor(private readonly config: AppConfiguration, private readonly dataService: DataService) {
+	constructor(private readonly config: AppConfiguration) {
 		this.client = new MirrorRestClient(this.config.mirrorRest);
 	}
 

--- a/webapp/src/assets/base.css
+++ b/webapp/src/assets/base.css
@@ -32,6 +32,7 @@ button {
 	transition:
 		background-color .3s cubic-bezier(0.55, 0, 0.1, 1),
 		box-shadow .1s cubic-bezier(0.55, 0, 0.1, 1);
+	cursor: pointer;
 }
 
 button:hover {

--- a/webapp/src/components/ProposalDetailView.vue
+++ b/webapp/src/components/ProposalDetailView.vue
@@ -1,31 +1,28 @@
 <script setup lang="ts">
-import { computed } from "vue";
-import VoteCount from "@/components/VoteCount.vue";
-import StatusDisplay from "@/components/StatusDisplay.vue";
 import EpochDateDisplay from "@/components/EpochDateDisplay.vue";
-import CastVote from "./CastVote.vue";
+import StatusDisplay from "@/components/StatusDisplay.vue";
+import VoteCount from "@/components/VoteCount.vue";
 import type { ProposalDetail } from "@/models/proposal";
 import { ProposalStatus } from "@/models/proposal-status";
-import VotesDisplay from "./VotesDisplay.vue";
-import PossibleLink from "./PossibleLink.vue";
-import { token } from "@/models/info";
-import TallySummary from "./TallySummary.vue";
+import { computed } from "vue";
 import BorderPanel from "./BorderPanel.vue";
+import CastVote from "./CastVote.vue";
+import PossibleLink from "./PossibleLink.vue";
+import TallySummary from "./TallySummary.vue";
+import VotesDisplay from "./VotesDisplay.vue";
 
 const props = defineProps<{
   proposal: ProposalDetail;
 }>();
 
 const summary = computed(() => {
-  const symbol = token.value.symbol || "";
-  const decimals = token.value.decimals || 0;
   if (props.proposal) {
     const total = props.proposal.votes.reduce((p, c) => p + c.tokenBalance, 0);
     return props.proposal.choices.map((answer, index) => {
       return {
-        symbol,
+        symbol: props.proposal.hcsToken.symbol,
         answer,
-        decimals,
+        decimals: props.proposal.hcsToken.decimals,
         count: props.proposal.tally[index] || 0,
         total,
       };
@@ -61,8 +58,7 @@ const summary = computed(() => {
         v-if="proposal.status === ProposalStatus.Voting"
       />
       <VotesDisplay
-        :votes="proposal.votes"
-        :choices="proposal.choices"
+        :proposal="proposal"
         v-if="proposal.status !== ProposalStatus.Queued"
       />
     </div>

--- a/webapp/src/components/TallySummary.vue
+++ b/webapp/src/components/TallySummary.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
-import TokenBalance from "./TokenBalance.vue";
-import { token } from "@/models/info";
-import ApprovedIcon from "./icons/ApprovedIcon.vue";
-import RejectedIcon from "./icons/RejectedIcon.vue";
-import IndeterminateIcon from "./icons/IndeterminateIcon.vue";
 import type { Proposal, ProposalDetail } from "@/models/proposal";
+import TokenBalance from "./TokenBalance.vue";
+import ApprovedIcon from "./icons/ApprovedIcon.vue";
+import IndeterminateIcon from "./icons/IndeterminateIcon.vue";
+import RejectedIcon from "./icons/RejectedIcon.vue";
 
 defineProps<{ proposal: Proposal | ProposalDetail }>();
 </script>
@@ -16,9 +15,9 @@ defineProps<{ proposal: Proposal | ProposalDetail }>();
     {{ proposal.choices[proposal.winner] }}
     <TokenBalance
       :amount="proposal.tally[proposal.winner]"
-      :decimals="token.decimals"
+      :decimals="proposal.hcsToken.decimals"
     />
-    <span class="symbol">${{ token.symbol }} </span>
+    <span class="symbol">${{ proposal.hcsToken.symbol }} </span>
     <span class="checksum">[{{ proposal.checksum }}]</span>
   </div>
   <div v-else class="indeterminate">

--- a/webapp/src/components/VotesDisplay.vue
+++ b/webapp/src/components/VotesDisplay.vue
@@ -1,26 +1,25 @@
 <script setup lang="ts">
-import type { Vote } from "@/models/proposal";
+import type { ProposalDetail } from "@/models/proposal";
 import BorderPanel from "./BorderPanel.vue";
 import TokenBalance from "./TokenBalance.vue";
-import { token } from "@/models/info";
 
-defineProps<{ votes: Vote[]; choices: string[] }>();
+defineProps<{ proposal: ProposalDetail }>();
 </script>
 
 <template>
   <BorderPanel>
     <template #header>Votes</template>
-    <div v-if="votes.length > 0" class="vote-list">
-      <template v-for="(vote, index) in votes" v-bind:key="index">
+    <div v-if="proposal.votes.length > 0" class="vote-list">
+      <template v-for="(vote, index) in proposal.votes" v-bind:key="index">
         <div class="circle"></div>
         <div>{{ vote.payerId }}</div>
-        <div class="choice">{{ choices[vote.vote] }}</div>
+        <div class="choice">{{ proposal.choices[vote.vote] }}</div>
         <TokenBalance
           class="balance"
           :amount="vote.tokenBalance"
-          :decimals="token?.decimals"
+          :decimals="proposal.hcsToken.decimals"
         />
-        <div>${{ token.symbol }}</div>
+        <div>${{ proposal.hcsToken.symbol }}</div>
       </template>
     </div>
     <div v-else>No Votes have been cast yet.</div>

--- a/webapp/src/models/proposal.ts
+++ b/webapp/src/models/proposal.ts
@@ -1,5 +1,5 @@
-import { ProposalStatus } from "@/models/proposal-status";
 import { dateFromEpoch } from "@/models/epoch";
+import { ProposalStatus } from "@/models/proposal-status";
 import type { EntityIdKeyString } from "@bugbytes/hapi-util";
 /**
  * Interface holding proposal information to display.
@@ -57,6 +57,15 @@ export interface Proposal {
    * Current UI status of the proposal.
    */
   status: ProposalStatus;
+  /**
+   * The hcsToken used for vote weighting for this proposal.
+   */
+  hcsToken: {
+    id: string;
+    symbol: string;
+    name: string;
+    decimals: number;
+  };
 }
 /**
  * Retrieves the full list of proposals from the remote server.
@@ -79,6 +88,7 @@ export async function getProposals(): Promise<Proposal[]> {
       checksum: item.checksum,
       status,
       expires,
+      hcsToken: item.hcsToken,
     };
   });
 }
@@ -92,24 +102,14 @@ export interface Vote {
   tokenBalance: number;
 }
 
-export interface ProposalDetail {
-  consensusTimestamp: string;
-  author: string;
-  title: string;
-  description: string;
+export interface ProposalDetail extends Proposal {
   discussion: string;
   scheme: string;
-  choices: string[];
-  expires: number;
-  status: ProposalStatus;
   threshold: number;
   ineligible: EntityIdKeyString[];
   startTimestamp: string;
   endTimestamp: string;
-  tally: number[];
   votes: Vote[];
-  winner: number;
-  checksum: string;
 }
 
 export async function getProposalDetails(
@@ -143,6 +143,7 @@ export async function getProposalDetails(
     checksum: json.checksum,
     status,
     expires,
+    hcsToken: json.hcsToken,
   };
 }
 

--- a/webapp/src/views/NewProposalPage.vue
+++ b/webapp/src/views/NewProposalPage.vue
@@ -1,27 +1,27 @@
 <script setup lang="ts">
-import { ref, computed } from "vue";
-import {
-  currentGateway,
-  GatewayProvider,
-  signalConnectWallet,
-} from "@/models/gateway";
 import BackLink from "@/components/BackLink.vue";
-import DateRangeDialog from "../components/DateRangeDialog.vue";
+import BorderPanel from "@/components/BorderPanel.vue";
+import ButtonPanel from "@/components/ButtonPanel.vue";
 import ProposalDetailView from "@/components/ProposalDetailView.vue";
-import type { BallotCreateParams } from "@/models/gateway";
-import type { ProposalDetail } from "@/models/proposal";
-import { ProposalStatus } from "@/models/proposal-status";
+import SubmitProposalDialog from "@/components/SubmitProposalDialog.vue";
 import {
   ceilingEpochFromDate,
   floorOrStandoffEpochFromDate,
 } from "@/models/epoch";
-import { trimOptionalText } from "@/models/text";
-import BorderPanel from "@/components/BorderPanel.vue";
-import ButtonPanel from "@/components/ButtonPanel.vue";
-import SubmitProposalDialog from "@/components/SubmitProposalDialog.vue";
-import LeafPageContainer from "../components/LeafPageContainer.vue";
+import type { BallotCreateParams } from "@/models/gateway";
+import {
+  GatewayProvider,
+  currentGateway,
+  signalConnectWallet,
+} from "@/models/gateway";
 import { pairedWallet } from "@/models/hashconnect";
 import { network } from "@/models/info";
+import type { ProposalDetail } from "@/models/proposal";
+import { ProposalStatus } from "@/models/proposal-status";
+import { trimOptionalText } from "@/models/text";
+import { computed, ref } from "vue";
+import DateRangeDialog from "../components/DateRangeDialog.vue";
+import LeafPageContainer from "../components/LeafPageContainer.vue";
 
 const dateDialog = ref<any>();
 const submitDialog = ref<any>();
@@ -75,6 +75,12 @@ function showPreview() {
     votes: [],
     winner: -1,
     checksum: "",
+    hcsToken: {
+      id: "0.0.0",
+      symbol: "VOTE",
+      name: "VOTE Token",
+      decimals: 3,
+    },
   };
 }
 


### PR DESCRIPTION
This PR allows the rules for the HCS topic to be updated.

Instead of requiring the rules to be submitted as the first message of the topic, we now filter rules into the data store in the same way we read in ballots and votes.

When a `define-rules` message type is detected in the sequence, it is forwarded on to a new hcs-rules-processing service. This validates the rules in the same way that the original rules were validated but instead of storing them in the config, we instead store them in the data service.

Due to the fact that messages are read in sequence order from the topic we can now assign the latest rules to the ballots as they are processed.

```
1 `define-rules`
2 `create-ballot` Uses rules #1
3. `cast-vote` Ballot #2
…
42. `create-ballot` Uses rules #1
43. `cast-vote` Ballot #2
43. `cast-vote` Ballot #42
...
103 `define-rules`
104. `create-ballot` Uses rules #103
105. `cast-vote` Ballot #2
106. `cast-vote` Ballot #42
107. `cast-vote` Ballot #104
...
```

The ballots have been updated to include the voting Token that will be used for the voting since it is no longer a global property. This has the side affect of allowing multiple ballots to be active which could be relying on different Tokens for votes.

One additional validation for the `define-rules` message is that it MUST have the same payer id as the original rule in the topic. This prevents just anyone updating the rules of the governance.

The new rules submitted to the topic override ALL the previous rules so there is no merging of old/new rules involved. The new rule is read in isolation as new ballots are submitted to the topic.

## Backwards Compatibility
These changes can be deployed on an existing topic and it will work as it did previously.

The only thing to consider is if the `HCS_START_DATE` is set to a time period where a rule doesn't exist after it, then the system will not read in any ballots as the ballots now rely on a rule coming from the data service.

## Outstanding
- [ ] Only the TypeScript server component has been updated with the new rules processing. The .NET server and CLI still need updating.
- [x] A decision on how `HCS_START_DATE` should work if no rules are defined after its timestamp needs to be met