### PR TITLE
Allow image name (prefix) and tag for containers to be overridden

### DIFF
--- a/server.yml
+++ b/server.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ./server
       dockerfile: Dockerfile
-    image: tcg/gov-api:local
+    image: ${DOCKER_IMAGE_PREFIX:-dovu/gov}-api:${DOCKER_IMAGE_TAG:-latest}
     restart: always
     ports:
       - ${SERVER_API_PORT}:80

--- a/server.yml
+++ b/server.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ./server
       dockerfile: Dockerfile
-    image: ${DOCKER_IMAGE_PREFIX:-dovu/gov}-api:${DOCKER_IMAGE_TAG:-latest}
+    image: ${DOCKER_IMAGE_PREFIX:-dovu/gov}-api:${DOCKER_IMAGE_TAG:-local}
     restart: always
     ports:
       - ${SERVER_API_PORT}:80

--- a/webapp.yml
+++ b/webapp.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: Dockerfile
       args:
         API_ENDPOINT: ${WEBAPP_API_ENDPOINT:-http://localhost:${SERVER_API_PORT}}
-    image: ${DOCKER_IMAGE_PREFIX:-dovu/gov}-ui:${DOCKER_IMAGE_TAG:-latest}
+    image: ${DOCKER_IMAGE_PREFIX:-dovu/gov}-ui:${DOCKER_IMAGE_TAG:-local}
     ports:
       - ${WEBAPP_PORT}:80
     depends_on:

--- a/webapp.yml
+++ b/webapp.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: Dockerfile
       args:
         API_ENDPOINT: ${WEBAPP_API_ENDPOINT:-http://localhost:${SERVER_API_PORT}}
-    image: tcg/gov-ui:local
+    image: ${DOCKER_IMAGE_NAME:-dovu/gov-ui}:${DOCKER_IMAGE_TAG:-latest}
     ports:
       - ${WEBAPP_PORT}:80
     depends_on:

--- a/webapp.yml
+++ b/webapp.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: Dockerfile
       args:
         API_ENDPOINT: ${WEBAPP_API_ENDPOINT:-http://localhost:${SERVER_API_PORT}}
-    image: ${DOCKER_IMAGE_NAME:-dovu/gov-ui}:${DOCKER_IMAGE_TAG:-latest}
+    image: ${DOCKER_IMAGE_PREFIX:-dovu/gov}-ui:${DOCKER_IMAGE_TAG:-latest}
     ports:
       - ${WEBAPP_PORT}:80
     depends_on:


### PR DESCRIPTION
When building the images for both the UI and API, the image name and tag are hardcoded into the docker compose files. This can cause problems when trying to deploy multiple versions from a single machine.

Consider the following sequence:

1. `cd /path/to/version1`
2. `docker compose up -d --build`
3. `cd /path/to/version2`
4. `docker compose up -d`

The version deployed in step 4 will be the one built in step2, so will have values injected from the `.env` file for version1. This will lead to misconfiguration of the deployed version.

Injection of configuration at build time isn't a good practice but is fairly common, so we need to provide a way to avoid the potential for clashes.

This change tags images based on values from the `.env` file (`DOCKER_IMAGE_PREFIX` and `DOCKER_IMAGE_TAG`) so that the two versions can be managed separately from the same source code. The fix requires `DOCKER_IMAGE_TAG` to be set differently in the `.env` file for each copy of the project. The `DOCKER_IMAGE_PREFIX` can be set, but will default to `dovu/gov`.